### PR TITLE
Fix CMakeLists.txt for Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required (VERSION 3.1)
+cmake_policy(SET CMP0076 NEW)
 
 project(MultiScaleErosion)
 


### PR DESCRIPTION
For some reason I had to add `cmake_policy(SET CMP0076 NEW)` for cmake to build on my machine